### PR TITLE
RFC 0011: Allow Intrinsic Functions and Pseudo-Parameter References in DeletionPolicy and UpdateReplacePolicy RFC

### DIFF
--- a/RFCs/0011-DeletionPolicy.md
+++ b/RFCs/0011-DeletionPolicy.md
@@ -2,11 +2,10 @@
 
 * **Original Author(s):**: @mingujo
 * **Tracking Issue**: [Tracking Issue](https://github.com/aws-cloudformation/cfn-language-discussion/issues/11)
-* **Reviewer**:  @cfn-language-and-tools-team
 
 # Summary
 
-With Language Extensions, you can use CloudFormation [intrinsic functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) and [Pseudo-Parameter references](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html) to dynamically determine a value for DeletionPolicy and UpdateReplacePolicy Resource attributes
+Use CloudFormation [intrinsic functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) and [Pseudo-Parameter references](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html) to dynamically determine a value for DeletionPolicy and UpdateReplacePolicy Resource attributes
 
 # Examples
 


### PR DESCRIPTION
### Language Enhancement Request For Comment

This is a request for comments about allowing Intrinsic Functions and Pseudo-Parameter References in `DeletionPolicy` and  `UpdateReplacePolicy` Resource Attributes RFC. See https://github.com/aws-cloudformation/cfn-language-discussion/issues/11 for additional details. 

---

## Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
