### PR TITLE
Update RFC tracking issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc-tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/rfc-tracking-issue.md
@@ -1,8 +1,10 @@
 ---
-Name: RFC Tracking Issue
-About: Tracking issue for an RFC
-Title: proposal title
-Labels: management/tracking, status/proposed
+name: RFC tracking issue
+about: Tracking issue for an RFC
+title: ''
+labels: management/tracking, status/proposed
+assignees: ''
+
 ---
 
 ## Description


### PR DESCRIPTION
Fix an issue where GitHub is unable to parse RFC tracking issue template.

---

## Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
